### PR TITLE
Correct install src paths

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,5 +18,5 @@ clean:
 
 install:
 	cp $(EXECUTABLE) /usr/local/bin/
-	cp ~/Systemd/ambed.service /lib/systemd/system/
-	cp ~/Systemd/ambed.timer /lib/systemd/system/
+	cp Systemd/ambed.service /lib/systemd/system/
+	cp Systemd/ambed.timer /lib/systemd/system/


### PR DESCRIPTION
The `Systemd/ambed.*` files are relative to the build directory.